### PR TITLE
Refactor worker templates for fx

### DIFF
--- a/cli/generators/gen_worker.go
+++ b/cli/generators/gen_worker.go
@@ -114,7 +114,7 @@ func (w *WorkerGenerator) buildRegistrationList() (bool, bool, []string, []strin
 		}
 		name := strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
 		structName := str.ToPascalCase(name)
-		acts = append(acts, fmt.Sprintf("activity.%s", structName))
+		acts = append(acts, structName)
 		hasActivities = true
 	}
 

--- a/cli/generators/templates/internal__workflow__registry.go.tmpl
+++ b/cli/generators/templates/internal__workflow__registry.go.tmpl
@@ -5,29 +5,27 @@ import (
   {{ .imports }}
 )
 
-var Activities = []interface{}{
-  {{- range .activities }}
-  {{ . }},
-  {{- end }}
-  {{- if eq (len .activities) 0 }}
-  // todo: add activities in internal/workflow/activity
-  {{- end }}
-}
-
-var Workflows = []interface{}{
+type Registry struct {
   {{- range .workflows }}
-  {{ . }},
+  {{ . }} *{{ . }}
   {{- end }}
-  {{- if eq (len .workflows) 0 }}
-  // todo: add workflows in internal/workflow
+  {{- range .activities }}
+  {{ . }} *activity.{{ . }}
+  {{- end }}
+  {{- if and (eq (len .workflows) 0) (eq (len .activities) 0) }}
+  /* todo: dependencies for workflows and activities */
   {{- end }}
 }
 
-func Register(w worker.Worker) {
-  for _, a := range Activities {
-    w.RegisterActivity(a)
-  }
-  for _, wf := range Workflows {
-    w.RegisterWorkflow(wf)
-  }
+func Register(w worker.Worker, deps Registry) {
+  {{- range .activities }}
+  w.RegisterActivity(deps.{{ . }}.Execute)
+  {{- end }}
+  {{- range .workflows }}
+  w.RegisterWorkflow(deps.{{ . }}.Execute)
+  {{- end }}
+  {{- if and (eq (len .workflows) 0) (eq (len .activities) 0) }}
+  // w.RegisterActivities(deps.ExampleWorkflow.Execute)
+  // w.RegisterActivities(deps.ExampleActivity.Execute)
+  {{- end }}
 }

--- a/cli/generators/templates/providers__provide_worker.go.tmpl
+++ b/cli/generators/templates/providers__provide_worker.go.tmpl
@@ -4,20 +4,28 @@ import (
   {{ .imports }}
 )
 
-func Worker(cfg *config.Config, lc fx.Lifecycle) (worker.Worker, error) {
+type ParamsWorker struct {
+  fx.In
+  workflow.Registry
+
+  Config *config.Config
+  Lc     fx.Lifecycle
+}
+
+func Worker(p *ParamsWorker) (worker.Worker, error) {
   c, err := client.Dial(client.Options{
-    HostPort: cfg.GetWorker().TemporalAddress,
-    Namespace: cfg.GetWorker().TemporalNamespace,
-    Logger: temporalutil.NewLoggerWithSlog(slog.Default()),
+    HostPort:  p.Config.GetWorker().TemporalAddress,
+    Namespace: p.Config.GetWorker().TemporalNamespace,
+    Logger:    temporalutil.NewLoggerWithSlog(slog.Default()),
   })
   if err != nil {
     return nil, err
   }
 
-  w := worker.New(c, cfg.GetWorker().TemporalTaskQueue, worker.Options{})
-  workflow.Register(w)
+  w := worker.New(c, p.Config.GetWorker().TemporalTaskQueue, worker.Options{})
+  workflow.Register(w, p.Registry)
 
-  lc.Append(fx.Hook{
+  p.Lc.Append(fx.Hook{
     OnStart: func(ctx context.Context) error {
       go func() {
         if err := w.Run(worker.InterruptCh()); err != nil {


### PR DESCRIPTION
## Summary
- use fx style dependencies for Temporal worker provider
- store workflow registrations via new `Registry` struct
- update worker generator to create fields for activities and workflows

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/..." Forbidden)*
- `go vet ./...` *(fails: Get "https://proxy.golang.org/..." Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846df0ffda8832b9f3e1f4f1f3ee98b