### PR TITLE
Add line editing and function checks to AST helper

### DIFF
--- a/cli/commands/generatecmd/task.go
+++ b/cli/commands/generatecmd/task.go
@@ -2,14 +2,8 @@ package generatecmd
 
 import (
 	"fmt"
-	"log/slog"
-	"os"
-	"strings"
 
 	"github.com/alexisvisco/goframe/cli/generators"
-	"github.com/alexisvisco/goframe/cli/generators/genhelper"
-	"github.com/alexisvisco/goframe/cli/generators/templates"
-	"github.com/alexisvisco/goframe/core/helpers/str"
 	"github.com/spf13/cobra"
 )
 
@@ -21,43 +15,14 @@ func taskCmd() *cobra.Command {
 		Long:  "Create a new task file with the specified name.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("migration name is required")
+				return fmt.Errorf("task name is required")
 			}
-
 			name := args[0]
 
-			g := generators.Generator{
-				GoModuleName: cmd.Context().Value("module").(string),
-				ORMType:      "gorm",
+			g := generators.Generator{GoModuleName: cmd.Context().Value("module").(string)}
+			if err := g.Task().Create(name, flagDescription); err != nil {
+				return fmt.Errorf("failed to create task: %w", err)
 			}
-
-			path := fmt.Sprintf("internal/task/task_%s.go", str.ToSnakeCase(name))
-			err := g.GenerateFile(generators.FileConfig{
-				Template:  templates.InternalTaskNewTaskGo,
-				Path:      path,
-				Condition: true,
-				Category:  generators.CategoryTasks,
-				Gen: func(g *genhelper.GenHelper) {
-					g.WithVar("name_kebab_case", str.ToKebabCase(name)).
-						WithVar("name_pascal_case", str.ToPascalCase(name)).
-						WithVar("name_camel_case", str.ToCamelCase(name)).
-						WithVar("description", str.ToSnakeCase(flagDescription))
-				},
-			})
-
-			slog.Info("created: task file", slog.String("file", path))
-
-			if err != nil {
-				return fmt.Errorf("failed to create task file: %w", err)
-			}
-
-			err = tryAddTaskToCliMain(name, cmd.Context().Value("module").(string))
-			if err != nil {
-				return fmt.Errorf("failed to add task to cli main: %w", err)
-			}
-
-			slog.Info("modified: cli main", slog.String("file", "cmd/cli/main.go"))
-
 			return nil
 		},
 	}
@@ -65,39 +30,4 @@ func taskCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&flagDescription, "description", "d", "", "Description of the task")
 
 	return cmd
-}
-
-func tryAddTaskToCliMain(name, modname string) error {
-	lineToFind := `cmdRoot := rootcmd.NewCmdRoot(`
-
-	file, err := os.ReadFile("cmd/cli/main.go")
-	if err != nil {
-		return fmt.Errorf("failed to read main.go: %w", err)
-	}
-
-	if !strings.Contains(string(file), lineToFind) {
-		return fmt.Errorf("line not found in main.go: %s", lineToFind)
-	}
-
-	// add import for the new task
-	importLine := `import (`
-	if !strings.Contains(string(file), importLine) {
-		return fmt.Errorf("import line not found in main.go: %s", importLine)
-	}
-	fileByLine := strings.Split(string(file), "\n")
-	newImport := fmt.Sprintf("\t\"%s/internal/task\"\n", modname)
-	if !strings.Contains(string(file), newImport) {
-		fileByLine = genhelper.InsertLineAfter(fileByLine, importLine, newImport)
-	}
-
-	newCommand := fmt.Sprintf("\t\t"+`rootcmd.WithCommand("task", task.New%sTask(app.Module(cfg))),`, str.ToPascalCase(name))
-	if !strings.Contains(string(file), newCommand) {
-		fileByLine = genhelper.InsertLineAfter(fileByLine, lineToFind, newCommand)
-	}
-
-	if err := os.WriteFile("cmd/cli/main.go", []byte(strings.Join(fileByLine, "\n")), 0644); err != nil {
-		return fmt.Errorf("failed to write main.go: %w", err)
-	}
-
-	return nil
 }

--- a/cli/generators/gen_service.go
+++ b/cli/generators/gen_service.go
@@ -126,43 +126,16 @@ func (s *ServiceGenerator) updateRegistry() error {
 
 func (s *ServiceGenerator) updateAppModule() error {
 	path := "internal/app/module.go"
-	data, err := os.ReadFile(path)
+	gf, err := genhelper.LoadGoFile(path)
 	if err != nil {
 		return nil
 	}
-	lines := strings.Split(string(data), "\n")
-	hasImport := false
-	for _, l := range lines {
-		if strings.Contains(l, "/internal/service") {
-			hasImport = true
-			break
-		}
+
+	gf.AddNamedImport("", filepath.Join(s.g.GoModuleName, "internal/service"))
+	if err := gf.AddReturnCompositeElement("Module", "fx.Provide(service.Dependencies...)"); err != nil {
+		return err
 	}
-	if !hasImport {
-		for i, l := range lines {
-			if strings.TrimSpace(l) == "import (" {
-				importLine := fmt.Sprintf("\t\"%s\"", filepath.Join(s.g.GoModuleName, "internal/service"))
-				lines = append(lines[:i+1], append([]string{importLine}, lines[i+1:]...)...)
-				break
-			}
-		}
-	}
-	hasProvide := false
-	for _, l := range lines {
-		if strings.Contains(l, "service.Dependencies") {
-			hasProvide = true
-			break
-		}
-	}
-	if !hasProvide {
-		for i, l := range lines {
-			if strings.Contains(l, "fx.Provide(") {
-				lines = append(lines[:i], append([]string{"    fx.Provide(service.Dependencies...),"}, lines[i:]...)...)
-				break
-			}
-		}
-	}
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
+	return gf.Save()
 }
 
 func (s *ServiceGenerator) Create(name string, withRepo bool) error {

--- a/cli/generators/gen_task.go
+++ b/cli/generators/gen_task.go
@@ -1,0 +1,52 @@
+package generators
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/alexisvisco/goframe/cli/generators/genhelper"
+	"github.com/alexisvisco/goframe/cli/generators/templates"
+	"github.com/alexisvisco/goframe/core/helpers/str"
+)
+
+type TaskGenerator struct {
+	g *Generator
+}
+
+func (t *TaskGenerator) createTaskFile(name, description string) error {
+	path := filepath.Join("internal/task", fmt.Sprintf("task_%s.go", str.ToSnakeCase(name)))
+	return t.g.GenerateFile(FileConfig{
+		Path:      path,
+		Template:  templates.InternalTaskNewTaskGo,
+		Category:  CategoryTasks,
+		Condition: true,
+		Gen: func(g *genhelper.GenHelper) {
+			g.WithVar("name_kebab_case", str.ToKebabCase(name)).
+				WithVar("name_pascal_case", str.ToPascalCase(name)).
+				WithVar("name_camel_case", str.ToCamelCase(name)).
+				WithVar("description", str.ToSnakeCase(description))
+		},
+	})
+}
+
+func (t *TaskGenerator) updateCliMain(name string) error {
+	path := "cmd/cli/main.go"
+	gf, err := genhelper.LoadGoFile(path)
+	if err != nil {
+		return err
+	}
+
+	gf.AddNamedImport("", filepath.Join(t.g.GoModuleName, "internal/task"))
+	arg := fmt.Sprintf("rootcmd.WithCommand(\"task\", task.New%sTask(app.Module(cfg)))", str.ToPascalCase(name))
+	if err := gf.AddArgToFuncCall("run", "rootcmd.NewCmdRoot", arg); err != nil {
+		return err
+	}
+	return gf.Save()
+}
+
+func (t *TaskGenerator) Create(name, description string) error {
+	if err := t.createTaskFile(name, description); err != nil {
+		return err
+	}
+	return t.updateCliMain(name)
+}

--- a/cli/generators/generator.go
+++ b/cli/generators/generator.go
@@ -147,11 +147,15 @@ func (g *Generator) Repository() *RepositoryGenerator {
 }
 
 func (g *Generator) Service() *ServiceGenerator {
-        return &ServiceGenerator{g: g}
+	return &ServiceGenerator{g: g}
 }
 
 func (g *Generator) Mailer() *MailerGenerator {
-        return &MailerGenerator{g: g}
+	return &MailerGenerator{g: g}
+}
+
+func (g *Generator) Task() *TaskGenerator {
+	return &TaskGenerator{g: g}
 }
 
 // CreateDirectory creates a directory if it doesn't exist

--- a/cli/generators/genhelper/astedit.go
+++ b/cli/generators/genhelper/astedit.go
@@ -1,0 +1,247 @@
+package genhelper
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"strings"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// GoFile helps to modify go source files using AST.
+type GoFile struct {
+	File *ast.File
+	fset *token.FileSet
+	path string
+}
+
+// LoadGoFile parses a Go file.
+func LoadGoFile(path string) (*GoFile, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+	return &GoFile{File: file, fset: fset, path: path}, nil
+}
+
+// Save writes the modified file back to disk.
+func (g *GoFile) Save(path ...string) error {
+	var p string
+	if len(path) > 0 {
+		p = path[0]
+	} else {
+		p = g.path
+	}
+	var buf bytes.Buffer
+	if err := format.Node(&buf, g.fset, g.File); err != nil {
+		return err
+	}
+	return os.WriteFile(p, buf.Bytes(), 0644)
+}
+
+// HasImport checks if the file already imports the given path.
+func (g *GoFile) HasImport(path string) bool {
+	for _, imp := range g.File.Imports {
+		if strings.Trim(imp.Path.Value, "\"") == path {
+			return true
+		}
+	}
+	return false
+}
+
+// AddNamedImport adds an import with an optional alias.
+func (g *GoFile) AddNamedImport(name, path string) {
+	if g.HasImport(path) {
+		return
+	}
+	astutil.AddNamedImport(g.fset, g.File, name, path)
+}
+
+// exprToString returns the formatted string representation of an expression.
+func (g *GoFile) exprToString(e ast.Expr) string {
+	var buf bytes.Buffer
+	format.Node(&buf, g.fset, e)
+	return buf.String()
+}
+
+// AddArgToFuncCall appends an argument to a specific function call inside the given function.
+// call should be of the form pkg.Func.
+func (g *GoFile) AddArgToFuncCall(funcName, call, arg string) error {
+	parts := strings.Split(call, ".")
+	if len(parts) != 2 {
+		return fmt.Errorf("call should be pkg.Func")
+	}
+	pkg, fun := parts[0], parts[1]
+
+	expr, err := parser.ParseExpr(arg)
+	if err != nil {
+		return err
+	}
+
+	ast.Inspect(g.File, func(n ast.Node) bool {
+		fd, ok := n.(*ast.FuncDecl)
+		if !ok || fd.Name.Name != funcName {
+			return true
+		}
+		ast.Inspect(fd.Body, func(nn ast.Node) bool {
+			ce, ok := nn.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := ce.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if ident.Name == pkg && sel.Sel.Name == fun {
+				// check if arg already exists
+				for _, a := range ce.Args {
+					if g.exprToString(a) == g.exprToString(expr) {
+						return false
+					}
+				}
+				ce.Args = append(ce.Args, expr)
+				return false
+			}
+			return true
+		})
+		return false
+	})
+	return nil
+}
+
+// AddReturnCompositeElement adds an element to the composite literal returned in the given function.
+func (g *GoFile) AddReturnCompositeElement(funcName, element string) error {
+	expr, err := parser.ParseExpr(element)
+	if err != nil {
+		return err
+	}
+
+	ast.Inspect(g.File, func(n ast.Node) bool {
+		fd, ok := n.(*ast.FuncDecl)
+		if !ok || fd.Name.Name != funcName {
+			return true
+		}
+		ast.Inspect(fd.Body, func(nn ast.Node) bool {
+			ret, ok := nn.(*ast.ReturnStmt)
+			if !ok {
+				return true
+			}
+			for _, res := range ret.Results {
+				cl, ok := res.(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				for _, el := range cl.Elts {
+					if g.exprToString(el) == g.exprToString(expr) {
+						return false
+					}
+				}
+				cl.Elts = append([]ast.Expr{expr}, cl.Elts...)
+				return false
+			}
+			return true
+		})
+		return false
+	})
+	return nil
+}
+
+func (g *GoFile) HasFunc(name string) bool {
+	for _, decl := range g.File.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok {
+			if fn.Recv == nil && fn.Name.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (g *GoFile) HasMethod(structName, methodName string) bool {
+	for _, decl := range g.File.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != methodName || fn.Recv == nil {
+			continue
+		}
+		if len(fn.Recv.List) == 0 {
+			continue
+		}
+		t := fn.Recv.List[0].Type
+		switch rt := t.(type) {
+		case *ast.StarExpr:
+			if ident, ok := rt.X.(*ast.Ident); ok && ident.Name == structName {
+				return true
+			}
+		case *ast.Ident:
+			if rt.Name == structName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func addLine(path, pattern, line string, before, regex bool) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(content), "\n")
+
+	var r *regexp.Regexp
+	if regex {
+		r, err = regexp.Compile(pattern)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i, l := range lines {
+		var match bool
+		if regex {
+			match = r.MatchString(l)
+		} else {
+			match = strings.Contains(l, pattern)
+		}
+		if match {
+			if before {
+				lines = append(lines[:i], append([]string{line}, lines[i:]...)...)
+			} else {
+				lines = append(lines[:i+1], append([]string{line}, lines[i+1:]...)...)
+			}
+			return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0644)
+		}
+	}
+	return fmt.Errorf("pattern not found")
+}
+
+func (g *GoFile) AddLineBeforeString(pattern, line string) error {
+	return addLine(g.path, pattern, line, true, false)
+}
+
+func (g *GoFile) AddLineAfterString(pattern, line string) error {
+	return addLine(g.path, pattern, line, false, false)
+}
+
+func (g *GoFile) AddLineBeforeRegex(pattern, line string) error {
+	return addLine(g.path, pattern, line, true, true)
+}
+
+func (g *GoFile) AddLineAfterRegex(pattern, line string) error {
+	return addLine(g.path, pattern, line, false, true)
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,8 +6,9 @@ require (
 	github.com/alexisvisco/goframe/core v0.0.0-20241022120000-abcdef123456
 	github.com/alexisvisco/goframe/db v0.0.0-20241022120000-abcdef123456
 	github.com/spf13/cobra v1.9.1
-	github.com/stretchr/testify v1.10.0
-	golang.org/x/mod v0.17.0
+        github.com/stretchr/testify v1.10.0
+        golang.org/x/mod v0.17.0
+        golang.org/x/tools v0.17.0
 )
 
 require (


### PR DESCRIPTION
## Summary
- extend `GoFile` with path information and update `Save` signature
- implement utilities to detect functions and methods
- add helpers for inserting lines before or after patterns
- rename `AddReturnElement` to `AddReturnCompositeElement`
- factorize task generator into `gen_task`

## Testing
- `go vet ./cli/...` *(fails: Get "https://proxy.golang.org/github.com/spf13/cobra/@v/v1.9.1.mod": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a825fc3f0832b80e54e3219dc84ab