### PR TITLE
Fix migration list ordering

### DIFF
--- a/cli/generators/gendb/gen_db.go
+++ b/cli/generators/gendb/gen_db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -173,6 +174,10 @@ func (g *DatabaseGenerator) buildMigrationList() (bool, bool, []string) {
 	if err != nil {
 		return false, false, []string{}
 	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
 
 	var migrations []string
 	hasSqlFiles := false


### PR DESCRIPTION
## Summary
- ensure SQL migrations are appended to `migrations.go`

## Testing
- `go test ./...` *(fails: directory prefix does not contain modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a9d39aa60832b9c369ae145660cda