### PR TITLE
Add cache docs and clarify build strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A quick overview of what you get out of the box:
 - **Task runner** for reusable CLI commands.
 - **Structured logging** via the canonical log helper built on `slog`.
 - **Storage** abstraction to handle attachments on disk or S3.
+- **Cache** with optional TTL and event notifications.
 
 ## Getting Started
 
@@ -46,7 +47,7 @@ For more commands check the built‑in help:
 bin/goframe --help
 ```
 
-`bin/goframe` always tries to compile the CLI into `bin/goframe.bin`. When compilation fails it reuses the previous binary if available. If no binary exists, it attempts `go mod tidy` once before asking you to fix the build errors.
+`bin/goframe` caches the compiled CLI under `~/.goframe/<module_hash>/bin/goframe`. The script rebuilds the binary when `cmd/cli/main.go` changes. If the build fails it runs `go mod tidy` once and falls back to the previous binary when possible.
 
 ## Documentation
 

--- a/docs/pages/_meta.tsx
+++ b/docs/pages/_meta.tsx
@@ -8,6 +8,7 @@ export default {
   worker: "Worker",
   mails: "Mails",
   storage: "Storage",
+  cache: "Cache",
   tasks: "Tasks",
   i18n: "I18n",
   cli: "CLI",

--- a/docs/pages/cache/_meta.tsx
+++ b/docs/pages/cache/_meta.tsx
@@ -1,0 +1,3 @@
+export default {
+  index: "Overview",
+};

--- a/docs/pages/cache/index.mdx
+++ b/docs/pages/cache/index.mdx
@@ -1,0 +1,23 @@
+# Cache
+
+GoFrame provides a simple cache layer backed by your database. Values are JSON encoded and may expire after a TTL.
+
+When using dependency injection, register the implementation as `contracts.Cache` so your services can depend on the interface.
+
+```go filename="usage.go"
+cache := cache.NewCache(cache.NewRepository(db), db, dsn)
+
+_ = cache.Put(ctx, "session:123", data, coretypes.WithTTL(time.Hour))
+var v SomeType
+_ = cache.Get(ctx, "session:123", &v)
+```
+
+You can watch for updates using PostgreSQL notifications:
+
+```go filename="watch.go"
+ch, _ := cache.Watch(ctx, "session:123")
+for ev := range ch {
+    fmt.Printf("%s %s", ev.Type, ev.Key)
+}
+```
+

--- a/docs/pages/cli/index.mdx
+++ b/docs/pages/cli/index.mdx
@@ -8,6 +8,6 @@ A `goframe` executable is generated in `cmd/cli/main.go`. Running `bin/goframe` 
 bin/goframe --help
 ```
 
-<Callout type="info">`bin/goframe` always tries to rebuild `bin/goframe.bin`. If the build fails it reuses the previous binary or runs `go mod tidy` before giving up.</Callout>
+<Callout type="info">`bin/goframe` caches the compiled binary in `~/.goframe/&lt;module_hash&gt;/bin/goframe`. It rebuilds the CLI when `cmd/cli/main.go` changes and falls back to the previous binary after one `go mod tidy` attempt if the build fails.</Callout>
 
 Commands are implemented with [Cobra](https://github.com/spf13/cobra). The default root command already exposes subcommands for tasks, database migrations and generators.


### PR DESCRIPTION
## Summary
- document cache feature
- mention contracts.Cache usage in cache docs
- clarify `bin/goframe` build caching strategy
- list cache docs in sidebar

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain modules)*
- `go test ./...` *(fails: directory prefix . does not contain modules)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6866acd80f74832b8e5eb70e39c9c02e